### PR TITLE
Fixed two memory leaks

### DIFF
--- a/src/cc/mallet/classify/AdaBoost.java
+++ b/src/cc/mallet/classify/AdaBoost.java
@@ -9,8 +9,11 @@
 
 package cc.mallet.classify;
 
-import cc.mallet.pipe.*;
-import cc.mallet.types.*;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.types.FeatureVector;
+import cc.mallet.types.Instance;
+import cc.mallet.types.LabelVector;
+import cc.mallet.util.ObjectUtils;
 
 /**
 	 AdaBoost
@@ -83,7 +86,7 @@ public class AdaBoost extends Classifier
     				+ numWeakClassifiersToUse);
 
     	FeatureVector fv = (FeatureVector) inst.getData();
-    	assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+    	assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
     	
     	int numClasses = getLabelAlphabet().size();
     	double[] scores = new double[numClasses];

--- a/src/cc/mallet/classify/AdaBoostM2.java
+++ b/src/cc/mallet/classify/AdaBoostM2.java
@@ -10,8 +10,11 @@ package cc.mallet.classify;
 
 import java.io.Serializable;
 
-import cc.mallet.pipe.*;
-import cc.mallet.types.*;
+import cc.mallet.pipe.Pipe;
+import cc.mallet.types.FeatureVector;
+import cc.mallet.types.Instance;
+import cc.mallet.types.LabelVector;
+import cc.mallet.util.ObjectUtils;
 
 
 /**
@@ -85,7 +88,7 @@ public class AdaBoostM2 extends Classifier implements Serializable
     				+ numWeakClassifiersToUse);
 
     	FeatureVector fv = (FeatureVector) inst.getData();
-    	assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+    	assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
     	
     	int numClasses = getLabelAlphabet().size();
     	double[] scores = new double[numClasses];

--- a/src/cc/mallet/classify/BalancedWinnow.java
+++ b/src/cc/mallet/classify/BalancedWinnow.java
@@ -18,6 +18,7 @@ import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Instance;
 import cc.mallet.types.LabelVector;
 import cc.mallet.types.MatrixOps;
+import cc.mallet.util.ObjectUtils;
 
 
 /** 
@@ -80,7 +81,7 @@ public class BalancedWinnow extends Classifier implements Serializable
         // Make sure the feature vector's feature dictionary matches
         // what we are expecting from our data pipe (and thus our notion
         // of feature probabilities.
-        assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+        assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
         int fvisize = fv.numLocations();
 
         // Take dot products

--- a/src/cc/mallet/classify/C45.java
+++ b/src/cc/mallet/classify/C45.java
@@ -17,9 +17,6 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import cc.mallet.classify.Boostable;
-import cc.mallet.classify.Classification;
-import cc.mallet.classify.Classifier;
 import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.FeatureVector;
@@ -28,6 +25,7 @@ import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
 import cc.mallet.util.MalletLogger;
 import cc.mallet.util.Maths;
+import cc.mallet.util.ObjectUtils;
 
 
 /**
@@ -65,7 +63,7 @@ public class C45 extends Classifier implements Boostable, Serializable
 	public Classification classify (Instance instance)
 	{
 		FeatureVector fv = (FeatureVector) instance.getData ();
-		assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+		assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
 		
 		Node leaf = getLeaf(m_root, fv);
 		return new Classification (instance, this, leaf.getGainRatio().getBaseLabelDistribution());

--- a/src/cc/mallet/classify/Classifier.java
+++ b/src/cc/mallet/classify/Classifier.java
@@ -14,22 +14,20 @@
 
 package cc.mallet.classify;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.*;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.AlphabetCarrying;
-import cc.mallet.types.FeatureVector;
+import cc.mallet.types.FeatureSelection;
 import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
-import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.Labeling;
-import cc.mallet.types.FeatureSelection;
+import cc.mallet.util.ObjectUtils;
 
 /**
  * Abstract parent of all Classifiers.
@@ -104,8 +102,9 @@ public abstract class Classifier implements AlphabetCarrying, Serializable
 	public boolean alphabetsMatch (AlphabetCarrying object)
 	{
 		Alphabet[] otherAlphabets = object.getAlphabets();
-		if (otherAlphabets.length == 2 && otherAlphabets[0] == getAlphabet() && otherAlphabets[1] == getLabelAlphabet())
+		if (otherAlphabets.length == 2 && ObjectUtils.equal(otherAlphabets[0], getAlphabet()) && ObjectUtils.equal(otherAlphabets[1], getLabelAlphabet())) {
 			return true;
+		}
 		return false;
 	}
 

--- a/src/cc/mallet/classify/ClassifierEnsemble.java
+++ b/src/cc/mallet/classify/ClassifierEnsemble.java
@@ -3,6 +3,7 @@ package cc.mallet.classify;
 import cc.mallet.types.Instance;
 import cc.mallet.types.LabelVector;
 import cc.mallet.types.MatrixOps;
+import cc.mallet.util.ObjectUtils;
 
 /* Copyright (C) 2005 Univ. of Massachusetts Amherst, Computer Science Dept.
    This file is part of "MALLET" (MAchine Learning for LanguagE Toolkit).
@@ -12,7 +13,7 @@ import cc.mallet.types.MatrixOps;
    information, see the file `LICENSE' included with this distribution. */
 
 /**
- * Classifer for an ensemble of classifers, combined with learned weights.
+ * Classifier for an ensemble of classifiers, combined with learned weights.
  * The procedure is to obtain the score from each classifier (typically p(y|x)),
  * perform the weighted sum of these scores, then exponentiate the summed
  * score for each class, and re-normalize the resulting per-class scores.
@@ -29,8 +30,9 @@ public class ClassifierEnsemble extends Classifier
   {
     this.ensemble = new Classifier[classifiers.length];
     for (int i = 0; i < classifiers.length; i++) {
-      if (i > 0 && ensemble[i-1].getLabelAlphabet() != classifiers[i].getLabelAlphabet())
+      if (i > 0 && !ObjectUtils.equal(ensemble[i-1].getLabelAlphabet(), classifiers[i].getLabelAlphabet())) {
         throw new IllegalStateException("LabelAlphabet's do not match.");
+      }
       ensemble[i] = classifiers[i];
     }
     System.arraycopy (classifiers, 0, ensemble, 0, classifiers.length);

--- a/src/cc/mallet/classify/DecisionTree.java
+++ b/src/cc/mallet/classify/DecisionTree.java
@@ -24,6 +24,7 @@ import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
 import cc.mallet.types.Labeling;
 import cc.mallet.util.MalletLogger;
+import cc.mallet.util.ObjectUtils;
 
 /**
    Decision Tree classifier.
@@ -61,7 +62,7 @@ public class DecisionTree extends Classifier implements Serializable //implement
 	public Classification classify (Instance instance)
 	{
 		FeatureVector fv = (FeatureVector) instance.getData ();
-		assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+		assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
 		
 		Node leaf = getLeaf (root, fv);
 		return new Classification (instance, this, leaf.labeling);

--- a/src/cc/mallet/classify/MCMaxEnt.java
+++ b/src/cc/mallet/classify/MCMaxEnt.java
@@ -18,13 +18,13 @@ import java.io.Serializable;
 
 import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Alphabet;
-import cc.mallet.types.DenseVector;
 import cc.mallet.types.FeatureSelection;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Instance;
 import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.LabelVector;
 import cc.mallet.types.MatrixOps;
+import cc.mallet.util.ObjectUtils;
 
 /**
  * Maximum Entropy classifier.
@@ -95,8 +95,7 @@ public class MCMaxEnt extends Classifier implements Serializable
         // Make sure the feature vector's feature dictionary matches
         // what we are expecting from our data pipe (and thus our notion
         // of feature probabilities.
-        assert (fv.getAlphabet ()
-                == this.instancePipe.getDataAlphabet ());
+        assert ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet());
 
         // Include the feature weights according to each label
         for (int li = 0; li < numLabels; li++) {
@@ -118,7 +117,7 @@ public class MCMaxEnt extends Classifier implements Serializable
         // Make sure the feature vector's feature dictionary matches
         // what we are expecting from our data pipe (and thus our notion
         // of feature probabilities.
-        assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+        assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
 			  //  arrayOutOfBounds if pipe has grown since training 
 			  //        int numFeatures = getAlphabet().size() + 1;
         int numFeatures = this.defaultFeatureIndex + 1;

--- a/src/cc/mallet/classify/MCMaxEntTrainer.java
+++ b/src/cc/mallet/classify/MCMaxEntTrainer.java
@@ -12,36 +12,27 @@ information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.classify;
 
 
-import java.util.logging.*;
-import java.util.*;
-import java.io.*;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.logging.Logger;
 
-import cc.mallet.classify.Classifier;
 import cc.mallet.optimize.LimitedMemoryBFGS;
 import cc.mallet.optimize.Optimizable;
 import cc.mallet.optimize.Optimizer;
-import cc.mallet.optimize.tests.*;
-import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Alphabet;
-import cc.mallet.types.ExpGain;
-import cc.mallet.types.FeatureInducer;
 import cc.mallet.types.FeatureSelection;
 import cc.mallet.types.FeatureVector;
-import cc.mallet.types.GradientGain;
-import cc.mallet.types.InfoGain;
 import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
-import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
-import cc.mallet.types.LabelVector;
 import cc.mallet.types.Labeling;
 import cc.mallet.types.MatrixOps;
-import cc.mallet.types.RankedFeatureVector;
-import cc.mallet.types.Vector;
 import cc.mallet.util.CommandOption;
 import cc.mallet.util.MalletLogger;
 import cc.mallet.util.MalletProgressMessageLogger;
 import cc.mallet.util.Maths;
+import cc.mallet.util.ObjectUtils;
 
 // Does not currently handle instances that are labeled with distributions
 // instead of a single label.
@@ -508,7 +499,7 @@ public class MCMaxEntTrainer extends ClassifierTrainer<MCMaxEnt> implements Boos
 				//logger.fine ("Instance "+ii+" labeling="+labeling);
 				FeatureVector fv = (FeatureVector) inst.getData ();
 				Alphabet fdict = fv.getAlphabet();
-				assert (fv.getAlphabet() == fd);
+				assert ObjectUtils.equal(fdict, fd);
 				int li = labeling.getBestIndex();
 				// The "2*" below is because there is one copy for the p(y|x)and another for the p(x|y).
 				MatrixOps.rowPlusEquals (constraints, numFeatures, li, fv, 2*instanceWeight);

--- a/src/cc/mallet/classify/MaxEnt.java
+++ b/src/cc/mallet/classify/MaxEnt.java
@@ -10,13 +10,12 @@ package cc.mallet.classify;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.io.PrintStream;
 
 import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Alphabet;
-import cc.mallet.types.DenseVector;
 import cc.mallet.types.FeatureSelection;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Instance;
@@ -24,6 +23,7 @@ import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.LabelVector;
 import cc.mallet.types.MatrixOps;
 import cc.mallet.types.RankedFeatureVector;
+import cc.mallet.util.ObjectUtils;
 
 /**
  * Maximum Entropy (AKA Multivariate Logistic Regression) classifier.
@@ -136,8 +136,7 @@ public class MaxEnt extends Classifier implements Serializable
 		// Make sure the feature vector's feature dictionary matches
 		// what we are expecting from our data pipe (and thus our notion
 		// of feature probabilities.
-		assert (fv.getAlphabet ()
-				== this.instancePipe.getDataAlphabet ());
+		assert ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet());
 
 		// Include the feature weights according to each label
 		for (int li = 0; li < numLabels; li++) {

--- a/src/cc/mallet/classify/MaxEntOptimizableByLabelDistribution.java
+++ b/src/cc/mallet/classify/MaxEntOptimizableByLabelDistribution.java
@@ -1,6 +1,5 @@
 package cc.mallet.classify;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.logging.Logger;
@@ -17,7 +16,7 @@ import cc.mallet.types.Labeling;
 import cc.mallet.types.MatrixOps;
 import cc.mallet.util.MalletLogger;
 import cc.mallet.util.MalletProgressMessageLogger;
-import cc.mallet.util.Maths;
+import cc.mallet.util.ObjectUtils;
 
 public class MaxEntOptimizableByLabelDistribution implements Optimizable.ByGradientValue  //, Serializable TODO needs to be done?
 {
@@ -102,7 +101,7 @@ public class MaxEntOptimizableByLabelDistribution implements Optimizable.ByGradi
 			//logger.fine ("Instance "+ii+" labeling="+labeling);
 			FeatureVector fv = (FeatureVector) inst.getData ();
 			Alphabet fdict = fv.getAlphabet();
-			assert (fv.getAlphabet() == fd);
+			assert ObjectUtils.equal(fdict, fd);
 
 			// Here is the difference between this code and the single label 
 			//  version: rather than only picking out the "best" index, 

--- a/src/cc/mallet/classify/MaxEntOptimizableByLabelLikelihood.java
+++ b/src/cc/mallet/classify/MaxEntOptimizableByLabelLikelihood.java
@@ -1,6 +1,5 @@
 package cc.mallet.classify;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.logging.Logger;
@@ -18,6 +17,7 @@ import cc.mallet.types.MatrixOps;
 import cc.mallet.util.MalletLogger;
 import cc.mallet.util.MalletProgressMessageLogger;
 import cc.mallet.util.Maths;
+import cc.mallet.util.ObjectUtils;
 
 public class MaxEntOptimizableByLabelLikelihood implements Optimizable.ByGradientValue {
 
@@ -108,7 +108,7 @@ public class MaxEntOptimizableByLabelLikelihood implements Optimizable.ByGradien
 			//logger.fine ("Instance "+ii+" labeling="+labeling);
 			FeatureVector fv = (FeatureVector) inst.getData ();
 			Alphabet fdict = fv.getAlphabet();
-			assert (fv.getAlphabet() == fd);
+			assert ObjectUtils.equal(fdict, fd);
 			int li = labeling.getBestIndex();
 			MatrixOps.rowPlusEquals (constraints, numFeatures, li, fv, instanceWeight);
 			// For the default feature, whose weight is 1.0

--- a/src/cc/mallet/classify/NaiveBayes.java
+++ b/src/cc/mallet/classify/NaiveBayes.java
@@ -8,16 +8,23 @@
 package cc.mallet.classify;
 
 
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.Serializable;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Arrays;
 
-import cc.mallet.classify.Classifier;
 import cc.mallet.pipe.Pipe;
-import cc.mallet.types.*;
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.FeatureVector;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import cc.mallet.types.LabelVector;
+import cc.mallet.types.Labeling;
+import cc.mallet.types.Multinomial;
 import cc.mallet.types.Multinomial.Logged;
+import cc.mallet.types.RankedFeatureVector;
+import cc.mallet.util.ObjectUtils;
 
 /**
  * A classifier that classifies instances according to the NaiveBayes method.
@@ -147,7 +154,7 @@ public class NaiveBayes extends Classifier implements Serializable
     // what we are expecting from our data pipe (and thus our notion
     // of feature probabilities.
     assert (instancePipe == null
-            || fv.getAlphabet () == instancePipe.getDataAlphabet ());
+            || ObjectUtils.equal(fv.getAlphabet(), instancePipe.getDataAlphabet()));
     int fvisize = fv.numLocations();
 
     prior.addLogProbabilities (scores);

--- a/src/cc/mallet/classify/RankMaxEnt.java
+++ b/src/cc/mallet/classify/RankMaxEnt.java
@@ -19,7 +19,6 @@ import java.io.ObjectOutputStream;
 
 import cc.mallet.pipe.Pipe;
 import cc.mallet.types.Alphabet;
-import cc.mallet.types.DenseVector;
 import cc.mallet.types.FeatureSelection;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.FeatureVectorSequence;
@@ -28,6 +27,7 @@ import cc.mallet.types.InstanceList;
 import cc.mallet.types.LabelAlphabet;
 import cc.mallet.types.LabelVector;
 import cc.mallet.types.MatrixOps;
+import cc.mallet.util.ObjectUtils;
 
 
 /**
@@ -87,9 +87,8 @@ public class RankMaxEnt extends MaxEnt
 			// Make sure the feature vector's feature dictionary matches
 			// what we are expecting from our data pipe (and thus our notion
 			// of feature probabilities.
-			assert (fv.getAlphabet ()
-							== this.instancePipe.getDataAlphabet ());
-			
+			assert ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet());
+
 			// Include the feature weights according to each label xxx is
 			// this correct ? we only calculate the dot prod of the feature
 			// vector with the "positiveLabel" weights
@@ -116,9 +115,8 @@ public class RankMaxEnt extends MaxEnt
 			// Make sure the feature vector's feature dictionary matches
 			// what we are expecting from our data pipe (and thus our notion
 			// of feature probabilities.
-			assert (fv.getAlphabet ()
-							== this.instancePipe.getDataAlphabet ());
-			
+			assert ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet());
+
 			// Include the feature weights according to each label
 			scores[instanceNumber] = parameters[0*numFeatures + defaultFeatureIndex]
 																 + MatrixOps.rowDotProduct (parameters, numFeatures,

--- a/src/cc/mallet/classify/RankMaxEntTrainer.java
+++ b/src/cc/mallet/classify/RankMaxEntTrainer.java
@@ -16,10 +16,8 @@ package cc.mallet.classify;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.logging.Logger;
 
 import cc.mallet.optimize.ConjugateGradient;
@@ -27,25 +25,18 @@ import cc.mallet.optimize.LimitedMemoryBFGS;
 import cc.mallet.optimize.Optimizable;
 import cc.mallet.optimize.Optimizer;
 import cc.mallet.types.Alphabet;
-import cc.mallet.types.ExpGain;
-import cc.mallet.types.FeatureInducer;
 import cc.mallet.types.FeatureSelection;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.FeatureVectorSequence;
-import cc.mallet.types.GradientGain;
-import cc.mallet.types.InfoGain;
 import cc.mallet.types.Instance;
 import cc.mallet.types.InstanceList;
 import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
-import cc.mallet.types.LabelVector;
 import cc.mallet.types.Labels;
 import cc.mallet.types.MatrixOps;
-import cc.mallet.types.RankedFeatureVector;
-import cc.mallet.util.CommandOption;
 import cc.mallet.util.MalletLogger;
 import cc.mallet.util.MalletProgressMessageLogger;
-import cc.mallet.util.Maths;
+import cc.mallet.util.ObjectUtils;
 
 
 /**
@@ -382,7 +373,7 @@ public class RankMaxEntTrainer extends MaxEntTrainer
 				}
 				FeatureVector fv = (FeatureVector)fvs.get(positiveIndex);
 				Alphabet fdict = fv.getAlphabet();
-				assert (fv.getAlphabet() == fd);
+				assert ObjectUtils.equal(fdict, fd);
 
 				// xxx ensure dimensionality of constraints correct
 				MatrixOps.rowPlusEquals (constraints, numFeatures, 0, fv, instanceWeight);

--- a/src/cc/mallet/classify/Winnow.java
+++ b/src/cc/mallet/classify/Winnow.java
@@ -17,6 +17,7 @@ import cc.mallet.pipe.Pipe;
 import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Instance;
 import cc.mallet.types.LabelVector;
+import cc.mallet.util.ObjectUtils;
 
 /** 
  * Classification methods of Winnow2 algorithm.
@@ -64,7 +65,7 @@ public class Winnow extends Classifier{
 		// Make sure the feature vector's feature dictionary matches
 		// what we are expecting from our data pipe (and thus our notion
 		// of feature probabilities.
-		assert (instancePipe == null || fv.getAlphabet () == this.instancePipe.getDataAlphabet ());
+		assert (instancePipe == null || ObjectUtils.equal(fv.getAlphabet(), this.instancePipe.getDataAlphabet()));
 		int fvisize = fv.numLocations();
 		
 		// Set the scores by summing wi*xi

--- a/src/cc/mallet/grmm/learning/GenericAcrfData2TokenSequence.java
+++ b/src/cc/mallet/grmm/learning/GenericAcrfData2TokenSequence.java
@@ -148,12 +148,12 @@ public class GenericAcrfData2TokenSequence extends Pipe {
       StringSpan span = new StringSpan (buf, start, end);
 
       while (j < maxFeatureIdx) {
-        span.setFeatureValue (toks[j].intern (), 1.0);
+        span.setFeatureValue (toks[j], 1.0);
         j++;
       }
 
       if (includeTokenText) {
-        span.setFeatureValue ((textFeaturePrefix+text).intern(), 1.0);
+        span.setFeatureValue (textFeaturePrefix + text, 1.0);
       }
 
       if (labelsAtEnd) {

--- a/src/cc/mallet/grmm/test/TestGenericAcrfData2TokenSequence.java
+++ b/src/cc/mallet/grmm/test/TestGenericAcrfData2TokenSequence.java
@@ -1,19 +1,23 @@
 package cc.mallet.grmm.test;
 
-import junit.framework.TestCase;
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.regex.Pattern;
 
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import cc.mallet.extract.StringTokenization;
 import cc.mallet.grmm.learning.GenericAcrfData2TokenSequence;
 import cc.mallet.pipe.Pipe;
 import cc.mallet.pipe.iterator.LineGroupIterator;
-import cc.mallet.types.*;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import cc.mallet.types.LabelAlphabet;
+import cc.mallet.types.LabelsSequence;
+import cc.mallet.types.TokenSequence;
 import cc.mallet.types.tests.TestSerializable;
+import cc.mallet.util.ObjectUtils;
 
 
 /**
@@ -69,7 +73,7 @@ public class TestGenericAcrfData2TokenSequence extends TestCase {
     l2.addThruPipe (new LineGroupIterator (new StringReader (sampleData2), Pattern.compile ("^$"), true));
 
     // the readResolve alphabet thing doesn't kick in on first deserialization
-    assertTrue (p.getTargetAlphabet () != p2.getTargetAlphabet ());
+    assertFalse (ObjectUtils.equal(p.getTargetAlphabet (), p2.getTargetAlphabet ()));
 
     assertEquals (1, l1.size ());
     assertEquals (1, l2.size ());

--- a/src/cc/mallet/pipe/PipeUtils.java
+++ b/src/cc/mallet/pipe/PipeUtils.java
@@ -6,8 +6,6 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.pipe;
 
-import cc.mallet.pipe.Pipe;
-import cc.mallet.pipe.SerialPipes;
 import cc.mallet.types.Alphabet;
 
 /**
@@ -38,7 +36,7 @@ public class PipeUtils {
   {
     if (p1.dataAlphabet == null) return p2.dataAlphabet;
     if (p2.dataAlphabet == null) return p1.dataAlphabet;
-    if (p1.dataAlphabet == p2.dataAlphabet) return p2.dataAlphabet;
+    if (p1.dataAlphabet.equals(p2.dataAlphabet)) return p2.dataAlphabet;
     throw new IllegalArgumentException ("Attempt to concat pipes with incompatible data dicts.");
   }
 
@@ -46,7 +44,7 @@ public class PipeUtils {
   {
     if (p1.targetAlphabet == null) return p2.targetAlphabet;
     if (p2.targetAlphabet == null) return p1.targetAlphabet;
-    if (p1.targetAlphabet == p2.targetAlphabet) return p2.targetAlphabet;
+    if (p1.targetAlphabet.equals(p2.targetAlphabet)) return p2.targetAlphabet;
     throw new IllegalArgumentException ("Attempt to concat pipes with incompatible target dicts.");
   }
 

--- a/src/cc/mallet/pipe/tests/TestPipeUtils.java
+++ b/src/cc/mallet/pipe/tests/TestPipeUtils.java
@@ -6,6 +6,9 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.pipe.tests;
 
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import cc.mallet.fst.SimpleTagger;
 import cc.mallet.pipe.Pipe;
 import cc.mallet.pipe.PipeUtils;
@@ -13,7 +16,6 @@ import cc.mallet.pipe.SerialPipes;
 import cc.mallet.pipe.SimpleTaggerSentence2TokenSequence;
 import cc.mallet.types.Alphabet;
 import cc.mallet.types.Instance;
-import junit.framework.*;
 
 /**
  * Created: Aug 28, 2005
@@ -66,7 +68,7 @@ public class TestPipeUtils extends TestCase {
     Alphabet dict = serial.getDataAlphabet ();
 
     assertEquals (3, dict.size ());
-    assertTrue (dict == p2.getDataAlphabet ());
+    assertEquals (p2.getDataAlphabet (), dict);
   }
 
   public void testConcatenateNullPipes ()
@@ -90,7 +92,7 @@ public class TestPipeUtils extends TestCase {
     // force resolving data alphabet
     Alphabet dict2 = p2.getDataAlphabet ();
 
-    assertTrue (dict1 != dict2);
+    assertFalse (dict1.equals(dict2));
 
     try {
       PipeUtils.concatenatePipes (p1, p2);

--- a/src/cc/mallet/topics/DMROptimizable.java
+++ b/src/cc/mallet/topics/DMROptimizable.java
@@ -7,26 +7,21 @@ package cc.mallet.topics;
  *   multinomial mixture models.
  */
 
-import cc.mallet.optimize.Optimizable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.logging.Logger;
+
 import cc.mallet.classify.MaxEnt;
-
-import cc.mallet.types.InstanceList;
-import cc.mallet.types.Instance;
+import cc.mallet.optimize.Optimizable;
 import cc.mallet.types.Alphabet;
-import cc.mallet.types.FeatureVector;
 import cc.mallet.types.Dirichlet;
+import cc.mallet.types.FeatureVector;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
 import cc.mallet.types.MatrixOps;
-
 import cc.mallet.util.MalletLogger;
 import cc.mallet.util.MalletProgressMessageLogger;
-
-import java.util.logging.*;
-import java.util.*;
-
-import java.text.NumberFormat;
-import java.text.DecimalFormat;
-
-import gnu.trove.TIntIntHashMap;
+import cc.mallet.util.ObjectUtils;
 
 public class DMROptimizable implements Optimizable.ByGradientValue {
 
@@ -113,7 +108,7 @@ public class DMROptimizable implements Optimizable.ByGradientValue {
 				continue;
 
 			FeatureVector features = (FeatureVector) instance.getData();
-			assert (features.getAlphabet() == alphabet);
+			assert ObjectUtils.equal(features.getAlphabet(), alphabet);
 
 			boolean hasNaN = false;
 

--- a/src/cc/mallet/topics/LDA.java
+++ b/src/cc/mallet/topics/LDA.java
@@ -7,11 +7,21 @@
 
 package cc.mallet.topics;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.util.Arrays;
-import java.io.*;
 
-import cc.mallet.types.*;
-import cc.mallet.util.ArrayUtils;
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import cc.mallet.util.ObjectUtils;
 import cc.mallet.util.Randoms;
 
 /**
@@ -108,7 +118,7 @@ public class LDA implements Serializable {
 		if (ilist == null) throw new IllegalStateException ("Must already have some documents first.");
 		for (Instance inst : additionalDocuments)
 			ilist.add(inst);
-		assert (ilist.getDataAlphabet() == additionalDocuments.getDataAlphabet());
+		assert ObjectUtils.equal(ilist.getDataAlphabet(), additionalDocuments.getDataAlphabet());
 		assert (additionalDocuments.getDataAlphabet().size() >= numTypes);
 		numTypes = additionalDocuments.getDataAlphabet().size();
 		int numNewDocs = additionalDocuments.size();

--- a/src/cc/mallet/topics/LDAHyper.java
+++ b/src/cc/mallet/topics/LDAHyper.java
@@ -9,18 +9,40 @@ package cc.mallet.topics;
 
 import gnu.trove.TIntIntHashMap;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.TreeSet;
-import java.util.Iterator;
-
-import java.util.zip.*;
-
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.zip.GZIPOutputStream;
 
-import cc.mallet.types.*;
+import cc.mallet.types.Alphabet;
+import cc.mallet.types.AugmentableFeatureVector;
+import cc.mallet.types.Dirichlet;
+import cc.mallet.types.FeatureSequence;
+import cc.mallet.types.FeatureSequenceWithBigrams;
+import cc.mallet.types.IDSorter;
+import cc.mallet.types.Instance;
+import cc.mallet.types.InstanceList;
+import cc.mallet.types.LabelAlphabet;
+import cc.mallet.types.LabelSequence;
+import cc.mallet.types.Labeling;
+import cc.mallet.types.MatrixOps;
+import cc.mallet.types.RankedFeatureVector;
+import cc.mallet.util.ObjectUtils;
 import cc.mallet.util.Randoms;
 
 /**
@@ -216,7 +238,7 @@ public class LDAHyper implements Serializable {
 			for (int fi = 0; fi < numTypes; fi++) 
 				typeTopicCounts[fi] = new TIntIntHashMap();
 			this.betaSum = beta * numTypes;
-		} else if (alphabet != this.alphabet) {
+		} else if (!ObjectUtils.equal(alphabet, this.alphabet)) {
 			throw new IllegalArgumentException ("Cannot change Alphabet.");
 		} else if (alphabet.size() != this.numTypes) {
 			this.numTypes = alphabet.size();

--- a/src/cc/mallet/types/AugmentableFeatureVector.java
+++ b/src/cc/mallet/types/AugmentableFeatureVector.java
@@ -110,7 +110,7 @@ public class AugmentableFeatureVector extends FeatureVector implements Serializa
 	 *  Adds all indices that are present in some other feature vector
 	 *  with value 1.0.
 	 *  Beware that this may have unintended effects if 
-	 *    <tt>fv.dictionary != this.dictionary</tt>
+	 *    <tt>!fv.dictionary.equals(this.dictionary)</tt>.
 	 */
 	public void add (FeatureVector fv)
 	{

--- a/src/cc/mallet/types/Dirichlet.java
+++ b/src/cc/mallet/types/Dirichlet.java
@@ -20,8 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import cc.mallet.types.Multinomial;
-import cc.mallet.util.Maths;
+import cc.mallet.util.ObjectUtils;
 import cc.mallet.util.Randoms;
 
 /** 
@@ -1563,10 +1562,8 @@ Bernoulli numbers. */
 		{
 			this.multinomials = new ArrayList<Multinomial>(multinomialsTraining);
 			for (int i = 1; i < multinomials.size(); i++)
-				if (((Multinomial)multinomials.get(i-1)).size()
-						!= ((Multinomial)multinomials.get(i)).size()
-						|| ((Multinomial)multinomials.get(i-1)).getAlphabet()
-						!= ((Multinomial)multinomials.get(i)).getAlphabet())
+				if (((Multinomial)multinomials.get(i-1)).size() != ((Multinomial)multinomials.get(i)).size()
+						|| !ObjectUtils.equal(((Multinomial)multinomials.get(i-1)).getAlphabet(), ((Multinomial)multinomials.get(i)).getAlphabet()))
 					throw new IllegalArgumentException
 					("All multinomials must have same size and Alphabet.");
 		}

--- a/src/cc/mallet/types/ExpGain.java
+++ b/src/cc/mallet/types/ExpGain.java
@@ -20,11 +20,14 @@
 
 package cc.mallet.types;
 
-import java.util.logging.*;
-import java.io.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.logging.Logger;
 
 import cc.mallet.classify.Classification;
 import cc.mallet.util.MalletLogger;
+import cc.mallet.util.ObjectUtils;
 
 public class ExpGain extends RankedFeatureVector
 {
@@ -70,7 +73,7 @@ public class ExpGain extends RankedFeatureVector
 
 		// Calculate p~[f] and q[f]
 		for (int i = 0; i < numInstances; i++) {
-			assert (classifications[i].getLabelAlphabet() == ilist.getTargetAlphabet());
+			assert ObjectUtils.equal(classifications[i].getLabelAlphabet(), ilist.getTargetAlphabet());
 			Instance inst = ilist.get(i);
 			Labeling labeling = inst.getLabeling ();
 			FeatureVector fv = (FeatureVector) inst.getData ();
@@ -156,7 +159,7 @@ public class ExpGain extends RankedFeatureVector
 					}
 			}
 			for (int i = 0; i < ilist.size(); i++) {
-				assert (classifications[i].getLabelAlphabet() == ilist.getTargetAlphabet());
+				assert ObjectUtils.equal(classifications[i].getLabelAlphabet(), ilist.getTargetAlphabet());
 				Instance inst = ilist.get(i);
 				Labeling labeling = inst.getLabeling ();
 				FeatureVector fv = (FeatureVector) inst.getData ();
@@ -246,7 +249,7 @@ public class ExpGain extends RankedFeatureVector
 		// Note that we are using a gaussian prior, so we don't multiply by (1/numInstances)
 		double[][] qeag = new double[numClasses][numFeatures];
 		for (int i = 0; i < ilist.size(); i++) {
-			assert (classifications[i].getLabelAlphabet() == ilist.getTargetAlphabet());
+			assert ObjectUtils.equal(classifications[i].getLabelAlphabet(), ilist.getTargetAlphabet());
 			Instance inst = ilist.get(i);
 			Labeling labeling = inst.getLabeling ();
 			FeatureVector fv = (FeatureVector) inst.getData ();
@@ -343,7 +346,7 @@ public class ExpGain extends RankedFeatureVector
 		
 		public RankedFeatureVector newRankedFeatureVector (InstanceList ilist)
 		{
-			assert (ilist.getTargetAlphabet() == classifications[0].getAlphabet());
+			assert ObjectUtils.equal(ilist.getTargetAlphabet(), classifications[0].getAlphabet());
 			return new ExpGain (ilist, classifications, gaussianPriorVariance);
 		}
 

--- a/src/cc/mallet/types/FeatureConjunction.java
+++ b/src/cc/mallet/types/FeatureConjunction.java
@@ -14,14 +14,17 @@
 
 package cc.mallet.types;
 
-import java.util.logging.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.regex.*;
-import java.io.*;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
-import cc.mallet.types.*;
 import cc.mallet.util.MalletLogger;
+import cc.mallet.util.ObjectUtils;
 
 public class FeatureConjunction implements Serializable
 {
@@ -269,8 +272,9 @@ public class FeatureConjunction implements Serializable
 	
 	public boolean satisfiedBy (FeatureVector fv)
 	{
-		if (fv.getAlphabet() != dictionary)
+		if (!ObjectUtils.equal(fv.getAlphabet(), dictionary)) {
 			throw new IllegalArgumentException ("Vocabularies do not match.");
+		}
 		int fvsize = fv.numLocations();
 		int fvl = 0;
 		for (int fcl = 0; fcl < features.length; fcl++) {
@@ -384,8 +388,9 @@ public class FeatureConjunction implements Serializable
 		public void add (FeatureConjunction fc)
 		{
 			if (conjunctions.size() > 0
-					&& fc.dictionary != ((FeatureConjunction)conjunctions.get(0)).dictionary)
+					&& !ObjectUtils.equal(fc.dictionary, ((FeatureConjunction)conjunctions.get(0)).dictionary)) {
 				throw new IllegalArgumentException ("Alphabet does not match.");
+			}
 			conjunctions.add (fc);
 		}
 

--- a/src/cc/mallet/types/FeatureVector.java
+++ b/src/cc/mallet/types/FeatureVector.java
@@ -14,16 +14,17 @@
 
 package cc.mallet.types;
 
-import java.util.HashMap;
-import java.util.Iterator;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Arrays;
-import java.util.logging.*;
-import java.io.*;
+import java.util.logging.Logger;
 
-import cc.mallet.types.Alphabet;
-import cc.mallet.types.FeatureSequence;
-import cc.mallet.types.Vector;
 import cc.mallet.util.MalletLogger;
+import cc.mallet.util.ObjectUtils;
 import cc.mallet.util.PropertyList;
 
 /**
@@ -251,7 +252,7 @@ public class FeatureVector extends SparseVector implements Serializable, Alphabe
    * (presumably more compact, dense) Alphabet. */
   public static FeatureVector newFeatureVector (FeatureVector fv, Alphabet newVocab, FeatureSelection fs)
   {
-    assert (fs.getAlphabet() == fv.dictionary);
+    assert ObjectUtils.equal(fs.getAlphabet(), fv.dictionary);
     if (fv.indices == null) {
       throw new UnsupportedOperationException("Not yet implemented for dense feature vectors.");
     }

--- a/src/cc/mallet/types/GradientGain.java
+++ b/src/cc/mallet/types/GradientGain.java
@@ -16,9 +16,12 @@
 
 package cc.mallet.types;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import cc.mallet.classify.Classification;
+import cc.mallet.util.ObjectUtils;
 
 public class GradientGain extends RankedFeatureVector
 {
@@ -41,7 +44,7 @@ public class GradientGain extends RankedFeatureVector
 		int fli; // feature location index
 		// Populate targetFeatureCount, et al
 		for (int i = 0; i < ilist.size(); i++) {
-			assert (classifications[i].getLabelAlphabet() == ilist.getTargetAlphabet());
+			assert ObjectUtils.equal(classifications[i].getLabelAlphabet(), ilist.getTargetAlphabet());
 			Instance inst = ilist.get(i);
 			Labeling labeling = inst.getLabeling ();
 			FeatureVector fv = (FeatureVector) inst.getData ();

--- a/src/cc/mallet/types/InstanceList.java
+++ b/src/cc/mallet/types/InstanceList.java
@@ -17,7 +17,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
@@ -34,8 +33,8 @@ import cc.mallet.pipe.SerialPipes;
 import cc.mallet.pipe.Target2Label;
 import cc.mallet.pipe.TokenSequence2FeatureSequence;
 import cc.mallet.pipe.iterator.RandomTokenSequenceIterator;
-
 import cc.mallet.util.MalletLogger;
+import cc.mallet.util.ObjectUtils;
 import cc.mallet.util.Randoms;
 
 /**
@@ -757,8 +756,9 @@ public InstanceList[] splitInOrder (double[] proportions) {
 	{
 		if (selectedFeatures != null
 				&& selectedFeatures.getAlphabet() != null  // xxx We allow a null vocabulary here?  See CRF3.java
-				&& selectedFeatures.getAlphabet() != getDataAlphabet())
+				&& !selectedFeatures.getAlphabet().equals(getDataAlphabet())) {
 			throw new IllegalArgumentException ("Vocabularies do not match");
+		}
 		featureSelection = selectedFeatures;
 	}
 
@@ -771,8 +771,9 @@ public InstanceList[] splitInOrder (double[] proportions) {
 	{
 		if (selectedFeatures != null) {
 			for (int i = 0; i < selectedFeatures.length; i++)
-				if (selectedFeatures[i].getAlphabet() != getDataAlphabet())
+				if (!ObjectUtils.equal(selectedFeatures[i].getAlphabet(), getDataAlphabet())) {
 					throw new IllegalArgumentException ("Vocabularies do not match");
+				}
 		}
 		perLabelFeatureSelection = selectedFeatures;
 	}
@@ -965,7 +966,7 @@ public InstanceList[] splitInOrder (double[] proportions) {
 		}
 		assert (pipe == null
 				|| pipe.getDataAlphabet () == null
-				|| pipe.getDataAlphabet () == dataAlphabet);
+				|| ObjectUtils.equal(pipe.getDataAlphabet (), dataAlphabet));
 		return dataAlphabet;
 	}
 	
@@ -978,7 +979,7 @@ public InstanceList[] splitInOrder (double[] proportions) {
 		}
 		assert (pipe == null
 				|| pipe.getTargetAlphabet () == null
-				|| pipe.getTargetAlphabet () == targetAlphabet);
+				|| ObjectUtils.equal(pipe.getTargetAlphabet (), targetAlphabet));
 		return targetAlphabet;
 	}
 	

--- a/src/cc/mallet/types/KLGain.java
+++ b/src/cc/mallet/types/KLGain.java
@@ -25,10 +25,11 @@
 
 package cc.mallet.types;
 
-import java.util.logging.*;
+import java.util.logging.Logger;
 
 import cc.mallet.classify.Classification;
 import cc.mallet.util.MalletLogger;
+import cc.mallet.util.ObjectUtils;
 
 public class KLGain extends RankedFeatureVector
 {
@@ -78,7 +79,7 @@ public class KLGain extends RankedFeatureVector
 		}
 
 		for (int i = 0; i < numInstances; i++) {
-			assert (classifications[i].getLabelAlphabet() == ilist.getTargetAlphabet());
+			assert ObjectUtils.equal(classifications[i].getLabelAlphabet(), ilist.getTargetAlphabet());
 			Instance inst = ilist.get(i);
 			Labeling labeling = inst.getLabeling ();
 			FeatureVector fv = (FeatureVector) inst.getData ();
@@ -129,7 +130,7 @@ public class KLGain extends RankedFeatureVector
 		double[][] qeag = new double[numClasses][numFeatures];
 		modelLabelWeightSum = 0;
 		for (int i = 0; i < ilist.size(); i++) {
-			assert (classifications[i].getLabelAlphabet() == ilist.getTargetAlphabet());
+			assert ObjectUtils.equal(classifications[i].getLabelAlphabet(), ilist.getTargetAlphabet());
 			Instance inst = ilist.get(i);
 			Labeling labeling = inst.getLabeling ();
 			FeatureVector fv = (FeatureVector) inst.getData ();

--- a/src/cc/mallet/types/LabelAlphabet.java
+++ b/src/cc/mallet/types/LabelAlphabet.java
@@ -11,11 +11,9 @@
 
 package cc.mallet.types;
 
+import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.io.*;
 
-import cc.mallet.types.Alphabet;
 /**
 		A mapping from arbitrary objects (usually String's) to integers
 		(and corresponding Label objects) and back.
@@ -24,8 +22,8 @@ import cc.mallet.types.Alphabet;
  */
 public class LabelAlphabet extends Alphabet implements Serializable
 {
-	ArrayList labels;
-		
+	private ArrayList labels;
+
 	public LabelAlphabet ()
 	{
 		super();
@@ -58,5 +56,31 @@ public class LabelAlphabet extends Alphabet implements Serializable
 	{
 		return (Label) labels.get(labelIndex);
 	}
-		
+
+	@Override
+	public boolean equals(Object obj) {
+	    if (this == obj) {
+	        return true;
+	    }
+	    if (!super.equals(obj)) {
+	        return false;
+	    }
+	    if (!(obj instanceof LabelAlphabet)) {
+	        return false;
+	    }
+	    LabelAlphabet other = (LabelAlphabet) obj;
+	    if (!this.labels.equals(other.labels)) {
+	        return false;
+	    }
+	    return true;
+	}
+
+	@Override
+	public int hashCode() {
+	    final int prime = 31;
+	    int result = super.hashCode();
+	    result = prime * result + this.labels.hashCode();
+	    return result;
+	}
+
 }

--- a/src/cc/mallet/types/LabelVector.java
+++ b/src/cc/mallet/types/LabelVector.java
@@ -14,8 +14,7 @@
 
 package cc.mallet.types;
 
-import cc.mallet.types.Label;
-import cc.mallet.types.RankedFeatureVector;
+import cc.mallet.util.ObjectUtils;
 
 public class LabelVector extends RankedFeatureVector implements Labeling
 {
@@ -81,7 +80,7 @@ public class LabelVector extends RankedFeatureVector implements Labeling
 
 	public double value (Label label)
 	{
-		assert (label.dictionary  == this.dictionary);
+		assert ObjectUtils.equal(label.dictionary, this.dictionary);
 		return values[this.location (label.toString ())];
 	}
 

--- a/src/cc/mallet/types/Multinomial.java
+++ b/src/cc/mallet/types/Multinomial.java
@@ -12,14 +12,12 @@
 package cc.mallet.types;
 
 
-import java.io.Serializable;
-import java.io.ObjectOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
-import cc.mallet.types.Alphabet;
-import cc.mallet.types.FeatureSequence;
-import cc.mallet.types.FeatureVector;
+import cc.mallet.util.ObjectUtils;
 import cc.mallet.util.Randoms;
 
 /**
@@ -365,8 +363,9 @@ public class Multinomial extends FeatureVector
 
 		public void increment (FeatureSequence fs, double scale)
 		{
-			if (fs.getAlphabet() != dictionary)
+			if (!ObjectUtils.equal(fs.getAlphabet(), dictionary)) {
 				throw new IllegalArgumentException ("Vocabularies don't match.");
+			}
 			for (int fsi = 0; fsi < fs.size(); fsi++)
 				increment (fs.getIndexAtPosition(fsi), scale);
 		}
@@ -378,8 +377,9 @@ public class Multinomial extends FeatureVector
 
 		public void increment (FeatureVector fv, double scale)
 		{
-			if (fv.getAlphabet() != dictionary)
+			if (!ObjectUtils.equal(fv.getAlphabet(), dictionary)) {
 				throw new IllegalArgumentException ("Vocabularies don't match.");
+			}
 			for (int fvi = 0; fvi < fv.numLocations(); fvi++)
 				// Originally, the value of the feature was not being taken into account here,
 				// so words were only counted once per document! - gdruck 

--- a/src/cc/mallet/types/RankedFeatureVector.java
+++ b/src/cc/mallet/types/RankedFeatureVector.java
@@ -25,6 +25,8 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.LinkedList;
 
+import cc.mallet.util.ObjectUtils;
+
 public class RankedFeatureVector extends FeatureVector
 {
 	int[] rankOrder;
@@ -177,7 +179,7 @@ public class RankedFeatureVector extends FeatureVector
 		if (fs == null) {
       return getMaxValuedIndex();
     }
-		assert (fs.getAlphabet() == dictionary);
+		assert ObjectUtils.equal(fs.getAlphabet(), dictionary);
 		// xxx Make this more efficient!  I'm pretty sure that Java BitSet's can do this more efficiently
 		int i = 0;
 		while (!fs.contains(rankOrder[i])) {

--- a/src/cc/mallet/types/tests/TestAlphabet.java
+++ b/src/cc/mallet/types/tests/TestAlphabet.java
@@ -44,7 +44,7 @@ public class TestAlphabet extends TestCase {
     dict.lookupIndex ("TEST2");
     dict.lookupIndex ("TEST3");
     Alphabet dict2 = (Alphabet) TestSerializable.cloneViaSerialization (dict);
-    assertTrue (dict == dict2);
+    assertEquals (dict, dict2);
   }
 
   public static Test suite ()

--- a/src/cc/mallet/types/tests/TestLabelAlphabet.java
+++ b/src/cc/mallet/types/tests/TestLabelAlphabet.java
@@ -6,14 +6,12 @@
    information, see the file `LICENSE' included with this distribution. */
 package cc.mallet.types.tests;
 
-import junit.framework.TestCase;
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import java.io.IOException;
 import java.io.Serializable;
 
-import cc.mallet.types.Alphabet;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import cc.mallet.types.Label;
 import cc.mallet.types.LabelAlphabet;
 
@@ -57,7 +55,7 @@ public class TestLabelAlphabet extends TestCase {
     Labelee l = new Labelee (dict, t1);
     Labelee l2 = (Labelee) TestSerializable.cloneViaSerialization (l);
 
-    assertTrue (l.dict == l2.dict);
+    assertEquals (l.dict, l2.dict);
     assertTrue (dict.lookupLabel("TEST1") == l.theLabel);
     assertTrue (dict.lookupLabel("TEST1") == l2.theLabel);
     assertTrue (l.theLabel == l2.theLabel);

--- a/src/cc/mallet/util/ObjectUtils.java
+++ b/src/cc/mallet/util/ObjectUtils.java
@@ -1,0 +1,19 @@
+package cc.mallet.util;
+
+
+public final class ObjectUtils {
+
+    // See also Guava's Objects.equal(Object, Object)
+    public static boolean equal(final Object lhs, final Object rhs) {
+        if (null == lhs) {
+            return (null == rhs);
+        } else {
+            return lhs.equals(rhs);
+        }
+    }
+
+    private ObjectUtils() {
+        // prevent external instantiation
+    }
+
+}


### PR DESCRIPTION
Fixed two memory leaks:
1. Unnecessary String.intern() call in GenericAcrfData2TokenSequence
2. Unnecessary static Map in Alphabet

The latter changes the equals() contract of Alphabet; I have implemented equals() and hashCode() in that class accordingly.
